### PR TITLE
Correctifs PHP 8 et route API checkPermissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .tx
 .editorconfig
 test
+scratch/

--- a/admin/doliwpshop.php
+++ b/admin/doliwpshop.php
@@ -50,38 +50,38 @@ $userapi = new User($db);
 $userapi->fetch($conf->global->DOLIWPSHOP_USERAPI_SET,'', '',0,$conf->entity);
 $userapi->getrights();
 //Rights invoices
-$userapi->rights->facture->lire ? 1 : $userapi->addrights(11);
-$userapi->rights->facture->creer ? 1 : $userapi->addrights(12);
-$userapi->rights->facture->paiment ? 1 : $userapi->addrights(16);
+empty($userapi->rights->facture->lire) ? $userapi->addrights(11) : 1;
+empty($userapi->rights->facture->creer) ? $userapi->addrights(12) : 1;
+empty($userapi->rights->facture->paiment) ? $userapi->addrights(16) : 1;
 //Rights propals
-$userapi->rights->propale->lire ? 1 : $userapi->addrights(21);
-$userapi->rights->propale->creer ? 1 : $userapi->addrights(22);
-$userapi->rights->propale->cloturer ? 1 : $userapi->addrights(26);
+empty($userapi->rights->propale->lire) ? $userapi->addrights(21) : 1;
+empty($userapi->rights->propale->creer) ? $userapi->addrights(22) : 1;
+empty($userapi->rights->propale->cloturer) ? $userapi->addrights(26) : 1;
 //Rights products
-$userapi->rights->produit->lire ? 1 : $userapi->addrights(31);
-$userapi->rights->produit->creer ? 1 : $userapi->addrights(32);
+empty($userapi->rights->produit->lire) ? $userapi->addrights(31) : 1;
+empty($userapi->rights->produit->creer) ? $userapi->addrights(32) : 1;
 //Rights orders
-$userapi->rights->commande->lire ? 1 : $userapi->addrights(81);
-$userapi->rights->commande->creer ? 1 : $userapi->addrights(82);
+empty($userapi->rights->commande->lire) ? $userapi->addrights(81) : 1;
+empty($userapi->rights->commande->creer) ? $userapi->addrights(82) : 1;
 //Rights tiers
-$userapi->rights->societe->lire ? 1 : $userapi->addrights(121);
-$userapi->rights->societe->creer ? 1 : $userapi->addrights(122);
-$userapi->rights->societe->supprimer ? 1 : $userapi->addrights(125);
-$userapi->rights->societe->exporter ? 1 : $userapi->addrights(126);
-$userapi->rights->societe->client->voir ? 1 : $userapi->addrights(262);
-$userapi->rights->societe->contact->lire ? 1 : $userapi->addrights(281);
+empty($userapi->rights->societe->lire) ? $userapi->addrights(121) : 1;
+empty($userapi->rights->societe->creer) ? $userapi->addrights(122) : 1;
+empty($userapi->rights->societe->supprimer) ? $userapi->addrights(125) : 1;
+empty($userapi->rights->societe->exporter) ? $userapi->addrights(126) : 1;
+empty($userapi->rights->societe->client->voir) ? $userapi->addrights(262) : 1;
+empty($userapi->rights->societe->contact->lire) ? $userapi->addrights(281) : 1;
 //Rights tags
-$userapi->rights->categorie->lire ? 1 : $userapi->addrights(241);
-$userapi->rights->categorie->creer ? 1 : $userapi->addrights(242);
+empty($userapi->rights->categorie->lire) ? $userapi->addrights(241) : 1;
+empty($userapi->rights->categorie->creer) ? $userapi->addrights(242) : 1;
 //Rights services
-$userapi->rights->service->lire ? 1 : $userapi->addrights(531);
-$userapi->rights->service->creer ? 1 : $userapi->addrights(532);
+empty($userapi->rights->service->lire) ? $userapi->addrights(531) : 1;
+empty($userapi->rights->service->creer) ? $userapi->addrights(532) : 1;
 //Rights stocks
-$userapi->rights->stock->lire ? 1 : $userapi->addrights(1001);
+empty($userapi->rights->stock->lire) ? $userapi->addrights(1001) : 1;
 //Rights events
-$userapi->rights->agenda->myactions->read ? 1 : $userapi->addrights(2401);
-$userapi->rights->propale->myactions->create  ? 1 : $userapi->addrights(2402);
-$userapi->rights->propale->myactions->delete  ? 1 : $userapi->addrights(2403);
+empty($userapi->rights->agenda->myactions->read) ? $userapi->addrights(2401) : 1;
+empty($userapi->rights->propale->myactions->create)  ? $userapi->addrights(2402) : 1;
+empty($userapi->rights->propale->myactions->delete)  ? $userapi->addrights(2403) : 1;
 
 /*
  * Actions
@@ -115,6 +115,11 @@ $connected = WPshopAPI::get('/wp-json/wpshop/v2/statut');
  * View
  */
 $page_name = "DoliWPshopSetup";
+
+if (!function_exists('curl_init')) {
+	setEventMessages('Attention : l\'extension PHP cURL est nécessaire pour le fonctionnement de DoliWPshop.', null, 'warnings');
+}
+
 llxHeader('', $langs->trans($page_name));
 
 // Subheader
@@ -138,13 +143,14 @@ if ($action == 'edit') {
 	print '<tr class="liste_titre"><td class="titlefield">'.$langs->trans("Parameter").'</td><td>'.$langs->trans("Value").'</td></tr>';
 
 	foreach($arrayofparameters as $key => $val) {
+		$value = isset($conf->global->$key) ? $conf->global->$key : '';
 		print '<tr class="oddeven"><td>';
 		print $form->textwithpicto($langs->trans($key),$langs->trans($key.'Tooltip'));
-		print '</td><td><input name="'.$key.'"  class="flat '.(empty($val['css'])?'minwidth200':$val['css']).'" value="' . $conf->global->$key . '"></td></tr>';
+		print '</td><td><input name="'.$key.'"  class="flat '.(empty($val['css'])?'minwidth200':$val['css']).'" value="' . $value . '"></td></tr>';
 	}
 
 	print '<tr><td>'.$langs->trans("DataArchiveOnDeletion").'</td><td>';
-	print '<input type="checkbox" id="data_archive_on_deletion" name="data_archive_on_deletion" '.($conf->global->WPSHOP_DATA_ARCHIVE_ON_DELETION ? ' checked=""' : '').'';
+	print '<input type="checkbox" id="data_archive_on_deletion" name="data_archive_on_deletion" '.(!empty($conf->global->WPSHOP_DATA_ARCHIVE_ON_DELETION) ? ' checked=""' : '').'';
 	print '</td></tr>';
 
 
@@ -162,9 +168,10 @@ if ($action == 'edit') {
 		print '<tr class="liste_titre"><td class="titlefield">'.$langs->trans("Parameter").'</td><td>'.$langs->trans("Value").'</td></tr>';
 
 		foreach($arrayofparameters as $key => $val)	{
+			$value = isset($conf->global->$key) ? $conf->global->$key : '';
 			print '<tr class="oddeven"><td>';
 			print $form->textwithpicto($langs->trans($key),$langs->trans($key.'Tooltip'));
-			print '</td><td>' . $conf->global->$key . '</td></tr>';
+			print '</td><td>' . $value . '</td></tr>';
 		}
 
 		print '<tr class="oddevent"><td>'.$langs->trans("CommunicationWordPress").'</td><td>';
@@ -177,7 +184,7 @@ if ($action == 'edit') {
 		print '</td></tr>';
 
 		print '<tr><td>'.$langs->trans("DataArchiveOnDeletion").'</td><td>';
-		print '<input type="checkbox" id="data_archive_on_deletion" name="data_archive_on_deletion" '.($conf->global->WPSHOP_DATA_ARCHIVE_ON_DELETION ? ' checked=""' : '').' disabled>';
+		print '<input type="checkbox" id="data_archive_on_deletion" name="data_archive_on_deletion" '.(!empty($conf->global->WPSHOP_DATA_ARCHIVE_ON_DELETION) ? ' checked=""' : '').' disabled>';
 		print '</td></tr>';
 
 		print '<tr><td>'.$langs->trans("ActivateTranslateLink").'</td><td>';

--- a/class/api_doliwpshop.class.php
+++ b/class/api_doliwpshop.class.php
@@ -72,6 +72,20 @@ class DoliWPshop extends DolibarrApi
 	}
 
 	/**
+	 * Check if the API key has permissions and the module is responsive
+	 *
+	 * @url GET /checkPermissions
+	 */
+	public function checkPermissions() {
+		return array(
+			'success' => array(
+				'code' => 200,
+				'message' => 'OK'
+			)
+		);
+	}
+
+	/**
 	 * @param integer $wp_id
 	 * @param integer $doli_id
 	 *

--- a/core/modules/modDoliWPshop.class.php
+++ b/core/modules/modDoliWPshop.class.php
@@ -144,7 +144,7 @@ class modDoliWPshop extends DolibarrModules {
 
 		$this->_load_tables('/doliwpshop/sql/');
 
-		if ( $conf->global->DOLIWPSHOP_USERAPI_SET ==  0 ) {
+		if ( !isset($conf->global->DOLIWPSHOP_USERAPI_SET) || $conf->global->DOLIWPSHOP_USERAPI_SET == 0 ) {
 			require_once DOL_DOCUMENT_ROOT.'/user/class/user.class.php';
 
 			$user = new User($this->db);
@@ -176,7 +176,7 @@ class modDoliWPshop extends DolibarrModules {
 		$extra_fields->addExtraField( 'wpshopurltradmultilangs', 'WPshop_Url_trad_multilangs', 'url', 101, '', 'product_lang', 1, 0,'','', 0,'','5' );
 		$extra_fields->addExtraField( 'language_code', 'WPML_code', 'varchar', 102, '10', 'product_lang', 1, 1,'','', 0,'','1' );
 
-		return $this->_init(null);
+		return $this->_init(array());
 	}
 
 	/**
@@ -190,6 +190,6 @@ class modDoliWPshop extends DolibarrModules {
 	 *
 	 */
 	public function remove( $options = '' ) {
-		return $this->_remove(null);
+		return $this->_remove(array());
 	}
 }

--- a/lib/api_doliwpshop.class.php
+++ b/lib/api_doliwpshop.class.php
@@ -34,7 +34,7 @@ class WPshopAPI {
 	 public function __construct() {
 			global $conf;
 		
-			self::$base = $conf->global->WPSHOP_URL_WORDPRESS;
+			self::$base = !empty($conf->global->WPSHOP_URL_WORDPRESS) ? $conf->global->WPSHOP_URL_WORDPRESS : '';
 		
 	 }
 		 
@@ -74,13 +74,17 @@ class WPshopAPI {
 		$data = json_encode( $data );
 		global $conf;
 		
+		if (empty($conf->global->WPSHOP_URL_WORDPRESS)) return array('status' => false, 'error_message' => 'WPSHOP_URL_WORDPRESS not configured');
+		
 		$api_url = $conf->global->WPSHOP_URL_WORDPRESS . '/' . $end_point;
 		
+		if (!function_exists('curl_init')) return array('status' => false, 'error_message' => 'cURL extension is missing');
+
 		$ch = curl_init(); 
 		curl_setopt($ch, CURLOPT_URL, $api_url); 
 		curl_setopt($ch, CURLOPT_HTTPHEADER, array(
 			'Content-Type: application/json',
-			'WPAPIKEY: ' . $conf->global->WPSHOP_TOKEN,
+			'WPAPIKEY: ' . (isset($conf->global->WPSHOP_TOKEN) ? $conf->global->WPSHOP_TOKEN : ''),
 			'Content-Length: ' . strlen( $data ),
 		) ); 
 		
@@ -91,9 +95,10 @@ class WPshopAPI {
 		
 		curl_close($ch);
 		
-		if ($output === NULL) {
+		if ($output === false || $output === NULL) {
 			return array(
-				'status' => NULL,
+				'status' => false,
+				'error_message' => 'cURL request failed'
 			);
 		}
 		
@@ -123,18 +128,24 @@ class WPshopAPI {
 	public static function get( $end_point ) {
 		global $conf;
 		
+		if (empty($conf->global->WPSHOP_URL_WORDPRESS)) return false;
+
 		$api_url = $conf->global->WPSHOP_URL_WORDPRESS . $end_point;
 	
+		if (!function_exists('curl_init')) return false;
+
 		$ch = curl_init(); 
 		curl_setopt($ch, CURLOPT_URL, $api_url); 
 		curl_setopt($ch, CURLOPT_HTTPHEADER, array(
 			'Content-Type: application/json',
-			'WPAPIKEY: ' . $conf->global->WPSHOP_TOKEN,
+			'WPAPIKEY: ' . (isset($conf->global->WPSHOP_TOKEN) ? $conf->global->WPSHOP_TOKEN : ''),
 		) ); 
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE); 
 		$output = curl_exec($ch); 
 		curl_close($ch); 
 		
+		if ($output === false) return false;
+
 		$output = json_decode( $output );
 		
 		return $output;

--- a/lib/doliwpshop.lib.php
+++ b/lib/doliwpshop.lib.php
@@ -40,6 +40,7 @@ function doliwpshopAdminPrepareHead()
 	$head[$h][2] = 'settings';
 	$h++;
 
+	$object = null;
 	complete_head_from_modules($conf, $langs, $object, $head, $h, 'doliwpshop');
 
 	return $head;


### PR DESCRIPTION
Résolution de nombreux avertissements et erreurs fatales liés à PHP 8 (valeurs nulles passées à str_replace, types de retours stricts, etc). Ajout de la route REST API 'checkPermissions' manquante pour permettre à WPshop de tester correctement la connexion.