### PR TITLE
Fix: Améliorations de la synchronisation des catégories (Issue #301 WPShop)

### DIFF
--- a/class/actions_doliwpshop.class.php
+++ b/class/actions_doliwpshop.class.php
@@ -96,6 +96,10 @@ class ActionsDoliWPshop
 				$categoryDoliWPshop->createCategoryOnWPshop($object);
 			}
 
+			if ($action == 'updatewp' && $connected === true && ! empty($object->array_options['options__wps_id']))
+			{
+				$categoryDoliWPshop->createCategoryOnWPshop($object); // This actually triggers a sync/pull from Dolibarr
+			}
 		}
 		if (in_array('thirdpartycard', explode(':', $parameters['context'])))
 		{
@@ -194,19 +198,19 @@ class ActionsDoliWPshop
 			print '<div class="inline-block divButAction"><a class="butActionRefused" title="'.$langs->trans("NotAvailableDolibarr").'" href="#">'.$langs->trans("CreateOnWPshop").'</a></div>';
 			return;
 		}
+
+		if ( isset( $_SERVER['HTTPS'] ) ) {
+			if ( $_SERVER['HTTPS'] == 'on' ) {
+			  $server_protocol = 'https';
+			} else {
+			  $server_protocol = 'http';
+			} 
+		} else {
+			$server_protocol = 'http';
+		}
 		
 		if (empty($object->array_options['options__wps_id'])) {
 
-			if ( isset( $_SERVER['HTTPS'] ) ) {
-				if ( $_SERVER['HTTPS'] == 'on' ) {
-				  $server_protocol = 'https';
-				} else {
-				  $server_protocol = 'http';
-				} 
-			} else {
-				$server_protocol = 'http';
-			  }
-		
 			$actual_link = $server_protocol . '://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
 			$actual_link .= '&action=createwp';
 			print '<div class="inline-block divButAction"><a class="butAction" href="' . $actual_link . '">'.$langs->trans("CreateOnWPshop").'</a></div>';
@@ -218,7 +222,14 @@ class ActionsDoliWPshop
 			} elseif (isset($object->element) && ($object->element == 'category' || $object->element == 'categorie')) {
 				print '<div class="inline-block divButAction"><a class="butAction" title="'.$langs->trans("ViewOnWPshop").'" href="' . $wp_url . '/wp-admin/term.php?taxonomy=wps-product-cat&tag_ID=' . $object->array_options['options__wps_id'] . '&post_type=wps-product" target="_blank" >'.$langs->trans("ViewOnWPshop").'</a></div>';
 			}
-			print '<div class="inline-block divButAction"><a class="butActionRefused" title="'.$langs->trans("NotAvailableObject").'" href="#">'.$langs->trans("CreateOnWPshop").'</a></div>';
+
+			if (isset($object->element) && ($object->element == 'category' || $object->element == 'categorie')) {
+				$actual_link_update = $server_protocol . '://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+				$actual_link_update .= '&action=updatewp';
+				print '<div class="inline-block divButAction"><a class="butAction" title="'.$langs->trans("UpdateOnWPshop").'" href="'.$actual_link_update.'">'.$langs->trans("UpdateOnWPshop").'</a></div>';
+			} else {
+				print '<div class="inline-block divButAction"><a class="butActionRefused" title="'.$langs->trans("NotAvailableObject").'" href="#">'.$langs->trans("CreateOnWPshop").'</a></div>';
+			}
 		}
 	}
 }

--- a/class/actions_doliwpshop.class.php
+++ b/class/actions_doliwpshop.class.php
@@ -165,9 +165,9 @@ class ActionsDoliWPshop
 					if (!empty($response) && isset($response->slug)) {
 						global $conf;
 						$slug = $response->slug;
-						$wp_url = !empty($conf->global->WPSHOP_URL_WORDPRESS) ? $conf->global->WPSHOP_URL_WORDPRESS : '';
+						$wp_url = !empty($conf->global->WPSHOP_URL_WORDPRESS) ? rtrim($conf->global->WPSHOP_URL_WORDPRESS, '/') : '';
 						$wps_id = $object->array_options['options__wps_id'];
-						$link = $wp_url . '/wp-admin/term.php?taxonomy=wps-product-cat&tag_ID=' . $wps_id;
+						$link = $wp_url . '/wp-admin/term.php?taxonomy=wps-product-cat&tag_ID=' . $wps_id . '&post_type=wps-product';
 						print '<tr><td>'.$langs->trans("WPshop Slug").'</td><td colspan="3"><a href="'.$link.'" target="_blank">'.$slug.'</a></td></tr>';
 					}
 				}
@@ -212,10 +212,11 @@ class ActionsDoliWPshop
 			print '<div class="inline-block divButAction"><a class="butAction" href="' . $actual_link . '">'.$langs->trans("CreateOnWPshop").'</a></div>';
 
 		} else {
+			$wp_url = !empty($conf->global->WPSHOP_URL_WORDPRESS) ? rtrim($conf->global->WPSHOP_URL_WORDPRESS, '/') : '';
 			if ($object->element == 'product' ) {
-				print '<div class="inline-block divButAction"><a class="butAction" title="'.$langs->trans("ViewOnWPshop").'" href="' . $conf->global->WPSHOP_URL_WORDPRESS . '/?post_type=wps-product&p=' . $object->array_options['options__wps_id'] . '" target="_blank" >'.$langs->trans("ViewOnWPshop").'</a></div>';
+				print '<div class="inline-block divButAction"><a class="butAction" title="'.$langs->trans("ViewOnWPshop").'" href="' . $wp_url . '/?post_type=wps-product&p=' . $object->array_options['options__wps_id'] . '" target="_blank" >'.$langs->trans("ViewOnWPshop").'</a></div>';
 			} elseif (isset($object->element) && ($object->element == 'category' || $object->element == 'categorie')) {
-				print '<div class="inline-block divButAction"><a class="butAction" title="'.$langs->trans("ViewOnWPshop").'" href="' . $conf->global->WPSHOP_URL_WORDPRESS . '/wp-admin/term.php?taxonomy=wps-product-cat&tag_ID=' . $object->array_options['options__wps_id'] . '" target="_blank" >'.$langs->trans("ViewOnWPshop").'</a></div>';
+				print '<div class="inline-block divButAction"><a class="butAction" title="'.$langs->trans("ViewOnWPshop").'" href="' . $wp_url . '/wp-admin/term.php?taxonomy=wps-product-cat&tag_ID=' . $object->array_options['options__wps_id'] . '&post_type=wps-product" target="_blank" >'.$langs->trans("ViewOnWPshop").'</a></div>';
 			}
 			print '<div class="inline-block divButAction"><a class="butActionRefused" title="'.$langs->trans("NotAvailableObject").'" href="#">'.$langs->trans("CreateOnWPshop").'</a></div>';
 		}

--- a/class/actions_doliwpshop.class.php
+++ b/class/actions_doliwpshop.class.php
@@ -210,9 +210,8 @@ class ActionsDoliWPshop
 		}
 		
 		if (empty($object->array_options['options__wps_id'])) {
-
 			$actual_link = $server_protocol . '://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
-			$actual_link .= '&action=createwp';
+			$actual_link .= '&action=createwp&token='.newToken();
 			print '<div class="inline-block divButAction"><a class="butAction" href="' . $actual_link . '">'.$langs->trans("CreateOnWPshop").'</a></div>';
 
 		} else {
@@ -225,7 +224,7 @@ class ActionsDoliWPshop
 
 			if (isset($object->element) && ($object->element == 'category' || $object->element == 'categorie')) {
 				$actual_link_update = $server_protocol . '://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
-				$actual_link_update .= '&action=updatewp';
+				$actual_link_update .= '&action=updatewp&token='.newToken();
 				print '<div class="inline-block divButAction"><a class="butAction" title="'.$langs->trans("UpdateOnWPshop").'" href="'.$actual_link_update.'">'.$langs->trans("UpdateOnWPshop").'</a></div>';
 			} else {
 				print '<div class="inline-block divButAction"><a class="butActionRefused" title="'.$langs->trans("NotAvailableObject").'" href="#">'.$langs->trans("CreateOnWPshop").'</a></div>';

--- a/class/category_doliwpshop.class.php
+++ b/class/category_doliwpshop.class.php
@@ -84,6 +84,7 @@ class CategoryDoliWPshop {
 		$response = WPshopAPI::post($url, array(
 			'doli_id' => $object->id,
 			'type'    => 'wps-product-cat',
+			'wp_id'   => !empty($object->array_options['options__wps_id']) ? $object->array_options['options__wps_id'] : 0,
         ));
 		
 		if ($response['status'] && !empty($response['data']['wp_object']['data']['id'])) {

--- a/class/category_doliwpshop.class.php
+++ b/class/category_doliwpshop.class.php
@@ -86,7 +86,7 @@ class CategoryDoliWPshop {
 			'type'    => 'wps-product-cat',
         ));
 		
-		if ($response['status']) {
+		if ($response['status'] && !empty($response['data']['wp_object']['data']['id'])) {
             $object->array_options['options__wps_id'] = $response['data']['wp_object']['data']['id'];
 
             $result = $object->insertExtraFields();
@@ -100,7 +100,8 @@ class CategoryDoliWPshop {
 				return 0;
 			}
 		} else {
-			setEventMessages($langs->trans("ErrorPostRequest") . $url . ' "' . $response['error_message'] . '"', null, 'errors');
+			$error_msg = isset($response['error_message']) ? $response['error_message'] : (isset($response['data']['message']) ? $response['data']['message'] : 'Invalid response');
+			setEventMessages($langs->trans("ErrorPostRequest") . $url . ' "' . $error_msg . '"', null, 'errors');
 			return -1;
 		}
 		

--- a/langs/fr_FR/doliwpshop.lang
+++ b/langs/fr_FR/doliwpshop.lang
@@ -80,3 +80,4 @@ RiskScore = Cotation du risque
 SellerMessage = Message du vendeur
 TranslateProductArchive = Traduction du produit archivé
 ErrorLanguageCode = WPML language code déjà utilisé :
+UpdateOnWPshop = Mettre à jour sur WPshop

--- a/lib/api_doliwpshop.class.php
+++ b/lib/api_doliwpshop.class.php
@@ -76,7 +76,7 @@ class WPshopAPI {
 		
 		if (empty($conf->global->WPSHOP_URL_WORDPRESS)) return array('status' => false, 'error_message' => 'WPSHOP_URL_WORDPRESS not configured');
 		
-		$api_url = $conf->global->WPSHOP_URL_WORDPRESS . '/' . $end_point;
+		$api_url = rtrim($conf->global->WPSHOP_URL_WORDPRESS, '/') . '/' . ltrim($end_point, '/');
 		
 		if (!function_exists('curl_init')) return array('status' => false, 'error_message' => 'cURL extension is missing');
 
@@ -130,7 +130,7 @@ class WPshopAPI {
 		
 		if (empty($conf->global->WPSHOP_URL_WORDPRESS)) return false;
 
-		$api_url = $conf->global->WPSHOP_URL_WORDPRESS . $end_point;
+		$api_url = rtrim($conf->global->WPSHOP_URL_WORDPRESS, '/') . '/' . ltrim($end_point, '/');
 	
 		if (!function_exists('curl_init')) return false;
 


### PR DESCRIPTION
Passe l'identifiant WordPress connu lors de la mise à jour manuelle des catégories pour éviter la création de doublons côté WordPress. Évite l'écrasement de l'ID WP en cas d'erreur de retour de l'API. Applique un token CSRF valide pour toutes les actions.